### PR TITLE
Add PipelineBuilder module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- No new entries below this line! -->
 
+## [1.1.0] - 2024-03-21
+
+## Added
+
+- Add `Pluggable.PipelineBuilder` to create multiple pipelines in the same module ([#58](https://github.com/mruoss/pluggable/pull/58))
+
 ## [1.0.1] - 2022-10-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ when deriving `Pluggable.Token`
 `Pluggable.StepBuilder` works just like `Plug.Builder`. See the
 module documentation for instructions.
 
+`Pluggable.PipelineBuilder` can be used to define and run multiple pipelines in 
+the same module. See the module documentation for instructions.
+
 ## Code Formatting
 
 When using the `Pluggable.StepBuilder`, you might want to format the usage

--- a/lib/pluggable/pipeline_builder.ex
+++ b/lib/pluggable/pipeline_builder.ex
@@ -1,0 +1,93 @@
+defmodule Pluggable.PipelineBuilder do
+  @moduledoc """
+  Build pluggable steps as pipelines of other steps. Use this only if you need
+  to define and run multiple distinct pipelines in the same module.
+
+  ## Examples
+      defmodule MyPipeline do
+        pipeline :foo do
+          plug SomePluggableStep
+          plug :inline_step
+        end
+
+        pipeline :bar do
+          plug AnotherPluggableStep
+          plug :inline_step
+        end
+      end
+
+  These pipelines can be run from within the same module:
+
+      Pluggable.run(token, [&foo(&1, [])])
+      Pluggable.run(another_token, [&bar(&1, [])])
+
+  Or they can be run from outside
+
+      Pluggable.run(token, [&MyPipeline.foo(&1, [])])
+      Pluggable.run(another_token, [&MyPipeline.bar(&1, [])])
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      @pluggable_pipeline nil
+
+      import Pluggable.Token
+      import Pluggable.PipelineBuilder, only: [step: 1, step: 2, pipeline: 2]
+    end
+  end
+
+  @doc """
+  Defines a step inside a pipeline.
+
+  See module doc for more information.
+  """
+  defmacro step(step, opts \\ []) do
+    quote do
+      if pipeline = @pluggable_pipeline do
+        @pluggable_pipeline [{unquote(step), unquote(opts), true} | pipeline]
+      else
+        raise "cannot define step at the PipelineBuilder level, step must be defined inside a pipeline"
+      end
+    end
+  end
+
+  @doc """
+  Defines a pluggable step as a pipeline of other steps.
+
+  See module doc for more information.
+  """
+  defmacro pipeline(step, do: block) do
+    with true <- is_atom(step),
+         imports = __CALLER__.macros ++ __CALLER__.functions,
+         {mod, _} <- Enum.find(imports, fn {_, imports} -> {step, 2} in imports end) do
+      raise ArgumentError,
+            "cannot define pipeline named #{inspect(step)} " <>
+              "because there is an import from #{inspect(mod)} with the same name"
+    end
+
+    block =
+      quote do
+        step = unquote(step)
+        @pluggable_pipeline []
+        unquote(block)
+      end
+
+    compiler =
+      quote unquote: false do
+        {token, body} = Pluggable.StepBuilder.compile(__ENV__, @pluggable_pipeline, [])
+
+        def unquote(step)(unquote(token), _), do: unquote(body)
+
+        @pluggable_pipeline nil
+      end
+
+    quote do
+      try do
+        unquote(block)
+        unquote(compiler)
+      after
+        :ok
+      end
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Pluggable.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/mruoss/pluggable"
-  @version "1.0.1"
+  @version "1.1.0"
 
   def project do
     [

--- a/test/pluggable/pipeline_builder_test.exs
+++ b/test/pluggable/pipeline_builder_test.exs
@@ -1,0 +1,55 @@
+defmodule Pluggable.PipelineBuilderTest do
+  use ExUnit.Case, async: true
+
+  defmodule Module do
+    import Pluggable.Token
+
+    def init(val) do
+      {:init, val}
+    end
+
+    def call(token, opts) do
+      stack = [{:call, opts} | List.wrap(token.assigns[:stack])]
+      assign(token, :stack, stack)
+    end
+  end
+
+  defmodule Pipeline do
+    use Pluggable.PipelineBuilder
+
+    pipeline :foo do
+      step Module, :step2
+      step Module, :step3
+    end
+  end
+
+  defmodule Foo do
+    def foo(x, y), do: x + y
+  end
+
+  test "runs the pipeline" do
+    assert Pluggable.run(%TestToken{}, [&Pipeline.foo(&1, [])]).assigns[:stack] == [
+             call: {:init, :step3},
+             call: {:init, :step2}
+           ]
+  end
+
+  test "raises" do
+    assert_raise(
+      ArgumentError,
+      "cannot define pipeline named :foo because there is an import from Pluggable.PipelineBuilderTest.Foo with the same name",
+      fn ->
+        defmodule FaultyPipeline do
+          use Pluggable.PipelineBuilder
+
+          import Foo
+
+          pipeline :foo do
+            step Module, :step2
+            step Module, :step3
+          end
+        end
+      end
+    )
+  end
+end

--- a/test/pluggable/step_builder_test.exs
+++ b/test/pluggable/step_builder_test.exs
@@ -1,4 +1,8 @@
 defmodule Pluggable.StepBuilderTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
   defmodule Module do
     import Pluggable.Token
 
@@ -7,7 +11,7 @@ defmodule Pluggable.StepBuilderTest do
     end
 
     def call(token, opts) do
-      stack = [{:call, opts} | token.assigns[:stack]]
+      stack = [{:call, opts} | List.wrap(token.assigns[:stack])]
       assign(token, :stack, stack)
     end
   end
@@ -78,10 +82,6 @@ defmodule Pluggable.StepBuilderTest do
     # Doesn't return a Pluggable.Token
     def faulty_function(_token, _opts), do: "foo"
   end
-
-  use ExUnit.Case, async: true
-
-  import ExUnit.CaptureLog
 
   test "exports the init/1 function" do
     assert Sample.init(:ok) == :ok


### PR DESCRIPTION
## Moduledoc

Build pluggable steps as pipelines of other steps. Use this only if you need
to define and run multiple distinct pipelines in the same module.

###  Examples


```ex
defmodule MyPipeline do
  pipeline :foo do
    plug SomePluggableStep
    plug :inline_step
  end

  pipeline :bar do
    plug AnotherPluggableStep
    plug :inline_step
  end
end
```

These pipelines can be run from within the same module:

```ex
    Pluggable.run(token, [&foo(&1, [])])
    Pluggable.run(another_token, [&bar(&1, [])])
```

Or they can be run from outside

```ex
    Pluggable.run(token, [&MyPipeline.foo(&1, [])])
    Pluggable.run(another_token, [&MyPipeline.bar(&1, [])])
```
